### PR TITLE
feat: add support for mobile view

### DIFF
--- a/src/features/recording/components/RecorderControls.tsx
+++ b/src/features/recording/components/RecorderControls.tsx
@@ -27,7 +27,7 @@ export const RecorderControls: React.FC<RecorderControlsProps> = ({
     return (
         <div className="flex flex-col gap-2 items-center">
             <div className="flex items-center gap-4 mb-2">
-                <span className="text-lg font-bold">
+                <span className="text-base sm:text-lg font-bold">
                     🎙️ {status === 'recording'
                     ? '녹음중'
                     : status === 'paused'
@@ -37,23 +37,48 @@ export const RecorderControls: React.FC<RecorderControlsProps> = ({
                             : '대기'}
                 </span>
                 {(status === 'recording' || status === 'paused') && (
-                    <span className="text-sm text-gray-500">{formatTime(elapsedSec)}</span>
+                    <span className="text-sm sm:text-base text-gray-500">{formatTime(elapsedSec)}</span> // responsive text size
                 )}
             </div>
-            <div className="flex gap-2">
+            <div className="flex flex-wrap justify-center gap-2">
                 {(status === 'idle' || status === 'stopped') && (
-                    <button className="btn" onClick={onStart}>시작</button>
+                    <button 
+                        className="btn w-full sm:w-auto min-w-[120px]" // vertical alignment on small screens
+                        onClick={onStart}
+                    >
+                        시작
+                    </button>
                 )}
                 {status === 'recording' && (
                     <>
-                        <button className="btn" onClick={onPause}>일시정지</button>
-                        <button className="btn" onClick={onStop}>중지</button>
+                        <button 
+                            className="btn w-full sm:w-auto min-w-[120px]" 
+                            onClick={onPause}
+                        >
+                            일시정지
+                        </button>
+                        <button 
+                            className="btn w-full sm:w-auto min-w-[120px]" 
+                            onClick={onStop}
+                        >
+                            중지
+                        </button>
                     </>
                 )}
                 {status === 'paused' && (
                     <>
-                        <button className="btn" onClick={onResume}>재개</button>
-                        <button className="btn" onClick={onStop}>중지</button>
+                        <button 
+                            className="btn w-full sm:w-auto min-w-[120px]" 
+                            onClick={onResume}
+                        >
+                            재개
+                        </button>
+                        <button 
+                            className="btn w-full sm:w-auto min-w-[120px]" 
+                            onClick={onStop}
+                        >
+                            중지
+                        </button>
                     </>
                 )}
             </div>

--- a/src/features/transcript/components/TranscriptChunkList.tsx
+++ b/src/features/transcript/components/TranscriptChunkList.tsx
@@ -26,22 +26,23 @@ export const TranscriptChunkList: React.FC<TranscriptChunkListProps& {
                                                                             aiResponses,
                                                                             aiRespondingIds,
                                                                         }) => (
-    <div className="flex flex-col gap-4 mt-4 max-h-[400px] overflow-y-auto">
+    <div className="flex flex-col gap-4 mt-4 max-h-[300px] lg:max-h-[400px] overflow-y-auto px-2"> 
         {chunks.length === 0 ? (
-            <div className="text-gray-400 text-center">녹음 청크가 없습니다.</div>
+            <div className="text-gray-400 text-center py-4">녹음 청크가 없습니다.</div>
         ) : (
             chunks.map((chunk) => (
-                <TranscriptChunkBlock
-                    key={chunk.id}
-                    chunk={chunk}
-                    isUploading={uploadingChunkIds.includes(chunk.id)}
-                    transcript={transcripts[chunk.id]}
-                    error={errors[chunk.id]}
-                    onUpload={onUpload}
-                    onAskAI={onAskAI}
-                    aiResponse={aiResponses?.[chunk.id]}
-                    isAIResponding={!!aiRespondingIds?.includes(chunk.id)}
-                />
+                <div key={chunk.id} className="transition-transform hover:scale-[1.02]">
+                    <TranscriptChunkBlock
+                        chunk={chunk}
+                        isUploading={uploadingChunkIds.includes(chunk.id)}
+                        transcript={transcripts[chunk.id]}
+                        error={errors[chunk.id]}
+                        onUpload={onUpload}
+                        onAskAI={onAskAI}
+                        aiResponse={aiResponses?.[chunk.id]}
+                        isAIResponding={!!aiRespondingIds?.includes(chunk.id)}
+                    />
+                </div>
             ))
         )}
     </div>

--- a/src/features/transcript/components/TranscriptDetailPane.tsx
+++ b/src/features/transcript/components/TranscriptDetailPane.tsx
@@ -21,7 +21,7 @@ export const TranscriptDetailPane: React.FC<TranscriptDetailPaneProps> = ({
                                                                           }) => {
     if (isLoading) {
         return (
-            <div className="w-full max-w-xl min-h-[140px] flex items-center justify-center bg-gray-50 border border-dashed border-gray-300 rounded-lg shadow-inner">
+            <div className="w-full max-w-xl min-h-[120px] sm:min-h-[140px] flex items-center justify-center bg-gray-50 border border-dashed border-gray-300 rounded-lg shadow-inner">
                 <span className="text-gray-400">로딩 중...</span>
             </div>
         );
@@ -29,7 +29,7 @@ export const TranscriptDetailPane: React.FC<TranscriptDetailPaneProps> = ({
 
     if (error) {
         return (
-            <div className="w-full max-w-xl min-h-[140px] flex items-center justify-center bg-red-50 border border-dashed border-red-300 rounded-lg shadow-inner">
+            <div className="w-full max-w-xl min-h-[120px] sm:min-h-[140px] flex items-center justify-center bg-red-50 border border-dashed border-red-300 rounded-lg shadow-inner">
                 <span className="text-red-500">{error}</span>
             </div>
         );
@@ -37,17 +37,17 @@ export const TranscriptDetailPane: React.FC<TranscriptDetailPaneProps> = ({
 
     if (!chunk || !transcript) {
         return (
-            <div className="w-full max-w-xl min-h-[140px] flex flex-col items-center justify-center bg-gray-50 border border-dashed border-gray-300 rounded-lg shadow-inner transition-all">
-                <span className="text-2xl text-gray-300 mb-2">📝</span>
-                <span className="text-gray-400 text-center leading-relaxed">
-          청크를 선택하면<br/>여기에 변환된 텍스트가 표시됩니다.
-        </span>
+            <div className="w-full max-w-xl min-h-[120px] sm:min-h-[140px] flex flex-col items-center justify-center bg-gray-50 border border-dashed border-gray-300 rounded-lg shadow-inner transition-all">
+                <span className="text-xl sm:text-2xl text-gray-300 mb-2">📝</span>
+                <span className="text-gray-400 text-center leading-relaxed text-sm sm:text-base">
+                    청크를 선택하면<br/>여기에 변환된 텍스트가 표시됩니다.
+                </span>
             </div>
         );
     }
 
     return (
-        <div className="w-full">
+        <div className="w-full p-4 bg-white dark:bg-gray-800 rounded-lg shadow-sm">
             <h2 className="font-bold mb-2">청크 변환 결과</h2>
             <div className="bg-gray-50 rounded p-3 shadow">
                 <div className="mb-1 text-xs text-gray-400">

--- a/src/features/transcript/widgets/RecordingSplitView.tsx
+++ b/src/features/transcript/widgets/RecordingSplitView.tsx
@@ -16,27 +16,28 @@ export const RecordingSplitView: React.FC<{
     const selectedChunk = chunks.find(c => c.id === selectedChunkId);
 
     return (
-        <div className="flex gap-4 w-full">
+        <div className="flex flex-col lg:flex-row gap-4 w-full">
             {/* 좌측: 청크 리스트 */}
-            <div className="w-1/2 max-w-[320px] min-w-[180px] border-r border-gray-200">
+            <div className="w-full lg:w-1/2 lg:max-w-[320px] lg:min-w-[180px] border-b lg:border-b-0 lg:border-r border-gray-200 pb-4 lg:pb-0">
                 <TranscriptChunkList
                     chunks={chunks}
                     uploadingChunkIds={uploadingChunkIds}
                     transcripts={transcripts}
                     errors={errors}
                     onUpload={onUpload}
-                    onChunkClick={setSelectedChunkId} // 이 부분!
+                    onChunkClick={setSelectedChunkId}
                 />
             </div>
 
             {/* 우측: 상세 transcript 뷰 */}
-            <TranscriptDetailPane
-                chunk={selectedChunk}
-                transcript={transcripts[selectedChunkId ?? ""]}
-                isLoading={/* 필요시 */ false}
-                error={errors[selectedChunkId ?? ""]}
-            />
-
+            <div className="flex-1">
+                <TranscriptDetailPane
+                    chunk={selectedChunk}
+                    transcript={transcripts[selectedChunkId ?? ""]}
+                    isLoading={false}
+                    error={errors[selectedChunkId ?? ""]}
+                />
+            </div>
         </div>
     );
 };

--- a/src/pages/RecordingPage.tsx
+++ b/src/pages/RecordingPage.tsx
@@ -30,26 +30,27 @@ const RecordingPage: React.FC = () => {
     const elapsedSec = useSimpleRecordingTimer(status);
 
     return (
-        <div className="max-w-5xl mx-auto p-4">
-            <h1 className="text-xl font-bold mb-4">🎙️ 녹음/변환 데모</h1>
+        <div className="max-w-5xl mx-auto p-4 min-h-screen">
+            <h1 className="text-xl sm:text-2xl font-bold mb-4">🎙️ 녹음/변환 데모</h1> 
 
-            <RecorderControls
-                status={status}
-                elapsedSec={elapsedSec}
-                onStart={start}
-                onStop={stop}
-                onPause={pause}
-                onResume={resume}
-            />
+            <div className="space-y-6">
+                <RecorderControls
+                    status={status}
+                    elapsedSec={elapsedSec}
+                    onStart={start}
+                    onStop={stop}
+                    onPause={pause}
+                    onResume={resume}
+                />
 
-            <RecordingSplitView
-                chunks={chunks}
-                uploadingChunkIds={uploadingChunkIds}
-                transcripts={transcripts}
-                errors={errors}
-                onUpload={upload}
-                // onAskAI, aiResponses, aiRespondingIds 등도 필요시 주입
-            />
+                <RecordingSplitView
+                    chunks={chunks}
+                    uploadingChunkIds={uploadingChunkIds}
+                    transcripts={transcripts}
+                    errors={errors}
+                    onUpload={upload}
+                />
+            </div>
 
             {/* (추가로 전체 초기화/다운로드 버튼, 안내 등도 필요시) */}
         </div>


### PR DESCRIPTION
녹음은 휴대폰에서 가장 쉽게 이루어지기 때문에, 일부 사용자들이 이 앱을 휴대폰에서 사용해보려는 것도 자연스러운 일인 것 같습니다. 그런데 현재는 작은 화면에서의 질의 기능이 구체적으로 지원되지 않고 있습니다.

![Image](https://github.com/user-attachments/assets/e5d08f35-1a1f-4bef-b458-3171c1a6eb03)

휴대폰 사용자도 웹사이트를 편하게 볼 수 있도록 코드를 수정했습니다.

변경사항은 다음과 같습니다:
- **`RecorderControls.tsx`**: 작은 화면에서 버튼들이 세로로 쌓이도록 변경.
- **`TranscriptChunkList.tsx`**: 세로 레이아웃을 구성하고 반응형 최대 높이 지원.
- **`TranscriptDetailPane.tsx`**: 컨테이너 및 내용의 반응형 크기 지원.
- **`RecordingSplitView.tsx`**: 작은 화면에서는 단일 열 레이아웃, 큰 화면에서는 두 열
- **`RecordingPage.tsx`**: 화면 크기에 따라 제목 크기 다르게 적용


![image](https://github.com/user-attachments/assets/bab836d6-d7b4-442f-947b-36761b16c0ad)

혹시 이상하거나 수정이 필요한 부분이 있다면 언제든지 알려주시면 바로 고치겠습니다. 감사합니다! 😊